### PR TITLE
Add function limitations to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ have a look at the options.
 - Types with self references and generics are not asserted correctly.
 - No class expressions (`const A = class { }`), only class declarations (`class A { }`) can be used.
 - `ExpressionWithTypeArguments` can only contain `PropertyAccessExpression`s as expression with an `Identifier` as name, recursively.
-- Function signatures are only type checked on arguments. Return types are not typechecked.
+- Function signatures are only typechecked on arguments. Return types are not typechecked.
 - No JSX support.
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ have a look at the options.
 - Types with self references and generics are not asserted correctly.
 - No class expressions (`const A = class { }`), only class declarations (`class A { }`) can be used.
 - `ExpressionWithTypeArguments` can only contain `PropertyAccessExpression`s as expression with an `Identifier` as name, recursively.
+- Function signatures are only type checked on arguments. Return types are not typechecked.
 - No JSX support.
 
 ## Options


### PR DESCRIPTION
Arguments are properly checked but return types are not.

Example:

```
interface Stringfier {
    f: (n: number) => string
}

let myF = {
    f: (n: number) => n
}

console.log(myF as Stringfier)
```

tsc spits out:
```
index.ts:9:13 - error TS2352: Conversion of type '{ f: (n: number) => number; }' to type 'Stringfier' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  Types of property 'f' are incompatible.
    Type '(n: number) => number' is not comparable to type '(n: number) => string'.
      Type 'number' is not comparable to type 'string'.

9 console.log(myF as Stringfier)
```

but if I modify it to:
```
interface Stringfier {
    f: (n: number) => string
}

let myF = {
    f: (n: number) => n
}

console.log(myF as any as Stringfier)
```

Then tsr doesn't catch anything.