### PR TITLE
Use computed outDir as commonDir in mutation context

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -217,7 +217,7 @@ function transformProgram(rootNames: string | string[], options?: Options, refle
   function createMutationContext(node: ts.Node, transformationContext: ts.TransformationContext): void {
     if (ts.isSourceFile(node) && currentSourceFile !== node) {
       currentSourceFile = node;
-      context = new MutationContext(node, options, program, host, scanner, resolvedEntryFiles, commonDir, transformationContext);
+      context = new MutationContext(node, options, program, host, scanner, resolvedEntryFiles, getOutDir(), transformationContext);
     }
   }
 


### PR DESCRIPTION
Addresses a bug which may cause a wrong relative path for the tsr declaration file (see #21). Backward compatibility needs to be checked before releasing.